### PR TITLE
chore: use valid key to example for config of readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Example:
 
 ```
 return [
-    'VitePlugin' => [
+    'ViteHelper' => [
         'forceProductionMode' => true,
         'mainJs' => 'main.ts',
     ],


### PR DESCRIPTION
Use `ViteHelper` instead `VitePlugin` to key of associative array